### PR TITLE
removed the latin small letter o with diaeresis from the Jotform CSS …

### DIFF
--- a/app/views/home/stewardship_form.erb
+++ b/app/views/home/stewardship_form.erb
@@ -381,7 +381,7 @@ JotForm.paymentExtrasOnTheFly([null,{"name":"clickTo","qid":"1","text":"Stewards
   transition-timing-function: ease;
   background-color: #ffffe0;
 }
-/* ömer */
+/* */
 .form-radio-item,
 .form-checkbox-item {
   padding-bottom: 0px !important;
@@ -390,7 +390,7 @@ JotForm.paymentExtrasOnTheFly([null,{"name":"clickTo","qid":"1","text":"Stewards
 .form-checkbox-item:last-child {
   padding-bottom: 0;
 }
-/* ömer */
+/* */
 .form-single-column .form-checkbox-item,
 .form-single-column .form-radio-item {
   width: 100%;


### PR DESCRIPTION
Hopefully this fixes the invalid byte sequence error with ruby